### PR TITLE
Develop

### DIFF
--- a/src/services/Date.ts
+++ b/src/services/Date.ts
@@ -1,26 +1,28 @@
 // @ts-nocheck
-import {
-  format,
-  startOfToday,
-  startOfWeek,
-  nextFriday,
-  nextSunday,
-  formatISO,
-} from "date-fns";
+import { format, startOfWeek, nextFriday, nextSunday } from "date-fns";
 import { ptBR } from "date-fns/locale";
 
 class DateClass {
   constructor() {
-    this.today = startOfToday();
+    // browser's way to create a Today's date from 00h
+    this.today = new Date(
+      new Date().getFullYear(),
+      new Date().getMonth(),
+      new Date().getDate()
+    );
     this.week = startOfWeek(this.today);
   }
 
   todayDate() {
-    return formatISO(this.today);
+    return this.today.toISOString();
   }
 
   readableDate(date: string): string {
-    return format(new Date(date), "iii',' dd 'de' MMMM", { locale: ptBR });
+    const formatted = format(new Date(date), "iii',' dd 'de' MMMM", {
+      locale: ptBR,
+    });
+
+    return formatted;
   }
 
   workingWeekStart() {

--- a/src/services/Date.ts
+++ b/src/services/Date.ts
@@ -1,22 +1,24 @@
 // @ts-nocheck
-import { format, startOfWeek, nextFriday, nextSunday } from "date-fns";
+import {
+  format,
+  startOfToday,
+  startOfWeek,
+  parseISO /* nextFriday, nextSunday */,
+} from "date-fns";
 import { ptBR } from "date-fns/locale";
 
 class DateClass {
   /**
    * Basic and Common elements to the Class
    *
+   * @warning ALWAYS parse date to parseISO() to keep a pattern and prevent bugs in Safari < v15.x.x
+   *
    * @constructor
    * @const {Date} today - Today's Date
    * @const {Date} week - First day of Week
    */
   constructor() {
-    // To prevent bugs on Safari, keep creation from browser's API
-    this.today = new Date(
-      new Date().getFullYear(),
-      new Date().getMonth(),
-      new Date().getDate()
-    );
+    this.today = startOfToday();
 
     this.week = startOfWeek(this.today);
   }
@@ -37,11 +39,11 @@ class DateClass {
    * @return {string}
    */
   readableDate(date: string): string {
-    const formatted = format(new Date(date), "iii',' dd 'de' MMMM", {
+    const weekAndMonthDay = format(parseISO(date), "iii',' dd 'de' MMMM", {
       locale: ptBR,
     });
 
-    return formatted;
+    return weekAndMonthDay;
   }
 
   // workingWeekStart() {

--- a/src/services/Date.ts
+++ b/src/services/Date.ts
@@ -3,20 +3,39 @@ import { format, startOfWeek, nextFriday, nextSunday } from "date-fns";
 import { ptBR } from "date-fns/locale";
 
 class DateClass {
+  /**
+   * Basic and Common elements to the Class
+   *
+   * @constructor
+   * @const {Date} today - Today's Date
+   * @const {Date} week - First day of Week
+   */
   constructor() {
-    // browser's way to create a Today's date from 00h
+    // To prevent bugs on Safari, keep creation from browser's API
     this.today = new Date(
       new Date().getFullYear(),
       new Date().getMonth(),
       new Date().getDate()
     );
+
     this.week = startOfWeek(this.today);
   }
 
-  todayDate() {
+  /**
+   * Today's date output
+   *
+   * @return {string} date formatted to ISO, on GMT time
+   */
+  todayDate(): string {
     return this.today.toISOString();
   }
 
+  /**
+   * Date formatted showing day of week, and month by name
+   *
+   * @example Terça, 31 de Janeiro
+   * @return {string}
+   */
   readableDate(date: string): string {
     const formatted = format(new Date(date), "iii',' dd 'de' MMMM", {
       locale: ptBR,
@@ -25,21 +44,21 @@ class DateClass {
     return formatted;
   }
 
-  workingWeekStart() {
-    return nextFriday(this.week);
-  }
+  // workingWeekStart() {
+  //   return nextFriday(this.week);
+  // }
 
-  formattedWeekStart() {
-    return this.readableDate(this.workingWeekStart());
-  }
+  // formattedWeekStart() {
+  //   return this.readableDate(this.workingWeekStart());
+  // }
 
-  workingWeekEnd() {
-    return nextSunday(this.week);
-  }
+  // workingWeekEnd() {
+  //   return nextSunday(this.week);
+  // }
 
-  formattedWeekEnd() {
-    return this.readableDate(this.workingWeekEnd());
-  }
+  // formattedWeekEnd() {
+  //   return this.readableDate(this.workingWeekEnd());
+  // }
 }
 
 export default new DateClass();


### PR DESCRIPTION
- Date Class documented using JS Docs pattern
- Date string now are always converted to ISO 8601 pattern, after crashes on iOS environments